### PR TITLE
Add caddy as webserver

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,8 @@
+:80
+root * /usr/share/caddy
+# Compress
+encode gzip zstd
+# Configure path router support for Angular
+try_files {path} {path}/ /index.html
+# Serve everything else like assets from the file system 
+file_server

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY . .
 
 RUN npm run build --prod
 
-FROM nginx:1.19-alpine
-
-COPY --from=builder /usr/src/app/dist/documentd-frontend /usr/share/nginx/html
+FROM caddy:2.2.0-alpine
+COPY Caddyfile /etc/caddy/Caddyfile
+COPY --from=builder /usr/src/app/dist/documentd-frontend /usr/share/caddy


### PR DESCRIPTION
Add caddy as lightweight webserver to serve and reroute requests. Replaced apache.

These changes also fixed #3 